### PR TITLE
reuse ust transport to prevent connections leak

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -151,7 +151,7 @@ func proxyGitlab(w http.ResponseWriter, r *http.Request) {
 		r.Header.Set("X-Forwarded-Proto", "https")
 	}
 	rp := httputil.NewSingleHostReverseProxy(u)
-	rp.Transport = &http.Transport{Dial: unixSocketDial}
+	rp.Transport = ust
 
 	(&wsproxy.ReverseProxy{rp}).ServeHTTP(w, r)
 }


### PR DESCRIPTION
make sure a single transport is used :

https://golang.org/pkg/net/http/#Transport

> Transports should be reused instead of created as needed. Transports are safe for concurrent use by multiple goroutines

> By default, Transport caches connections for future re-use. This may leave many open connections when accessing many hosts. This behavior can be managed using Transport's CloseIdleConnections method and the MaxIdleConnsPerHost and DisableKeepAlives fields.